### PR TITLE
Collapse vignette

### DIFF
--- a/vignettes/compartmap_vignette.Rmd
+++ b/vignettes/compartmap_vignette.Rmd
@@ -13,7 +13,9 @@ vignette: >
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding[utf8]{inputenc}
 ---
-
+```{r knitsetup, message=FALSE, warning=FALSE, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, warning = TRUE)
+```
 # Compartmap: Shrunken A/B compartment inference from ATAC-seq and methylation arrays
 
 Compartmap extends methods to perform A/B compartment inference from (sc)ATAC-seq and methylation arrays originally proposed by Fortin and Hansen 2015, Genome Biology (https://genomebiology.biomedcentral.com/articles/10.1186/s13059-015-0741-y). Originally, Fortin and Hansen demonstrated that chromatin conformation could be inferred from (sc)ATAC-seq, bisulfite sequencing, DNase-seq and methylation arrays, similar to the results provided by HiC. Thus, in addition to the base information provided by the aforementioned assays, chromatin state could also be inferred. However, these data were restricted to group level A/B compartment inference.
@@ -27,7 +29,7 @@ The expected input for compartmap is either a RangedSummarizedExperiment object 
 
 ```{r loadData}
 
-library(compartmap)
+suppressPackageStartupMessages(library(compartmap))
 library(GenomicRanges)
 library(Homo.sapiens)
 
@@ -76,7 +78,7 @@ plotAB(array_compartments[,6], ylim = c(-0.2, 0.2), unitarize = TRUE, top.col = 
 plotAB(array_compartments[,7], ylim = c(-0.2, 0.2), unitarize = TRUE, top.col = "seagreen")
 
 #Embed with UMAP for unsupervised clustering
-library(uwot)
+suppressPackageStartupMessages(library(uwot))
 embed_compartments <- umap(t(array_compartments), n_neighbors = 3, metric = "manhattan", n_components = 5, n_trees = 100)
 
 #Visualize embedding

--- a/vignettes/compartmap_vignette.Rmd
+++ b/vignettes/compartmap_vignette.Rmd
@@ -30,8 +30,8 @@ The expected input for compartmap is either a RangedSummarizedExperiment object 
 ```{r loadData}
 
 suppressPackageStartupMessages(library(compartmap))
-library(GenomicRanges)
-library(Homo.sapiens)
+suppressPackageStartupMessages(library(GenomicRanges))
+suppressPackageStartupMessages(library(Homo.sapiens))
 
 #Load in some example methylation array data
 #This data is derived from https://f1000research.com/articles/5-1281/v3


### PR DESCRIPTION
The vignette has many lines from loading libraries. I attempted to reduce the space they take by collapsing the output and suppressing the start up messages.

Also note that the plotly figure at the end of the vignette is not rendered in the Bioconductor site.