### PR TITLE
Add missing dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Encoding: UTF-8
 License: GPL-3 + file LICENSE
 biocViews: Genetics, Epigenetics, ATACSeq, RNASeq, SingleCell
 Depends: 
+   csaw,
    R (>= 4.1.0),
    SummarizedExperiment,
    RaggedExperiment,
@@ -40,11 +41,13 @@ Imports:
    RMTstat,
    impute
 Suggests:
+   BiocStyle,
    covr,
    testthat,
    knitr,
    Rcpp,
    rmarkdown,
+   SingleCellExperiment,
    markdown
 RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
Fixes #25 

Add `csaw` to `Depends` and `BiocStyle` and `SingleCellExperiment` to `Suggests`.
I am not sure why but moving `csaw` to `Suggests` does not help,