### PR TITLE
Refactor bootstrapCompartments

### DIFF
--- a/R/bootstrapCompartments.R
+++ b/R/bootstrapCompartments.R
@@ -71,8 +71,7 @@ bootstrapCompartments <- function(obj, original.obj, bootstrap.samples = 1000,
       colnames(boot.mean) <- "globalMean"
       s.bins <- shrinkBins(obj, original.obj, prior.means = boot.mean,
                            chr = chr, res = res, assay = assay, genome = genome)
-      if (group) cor.bins <- getCorMatrix(s.bins, squeeze = FALSE)
-      if (isFALSE(group)) cor.bins <- getCorMatrix(s.bins, squeeze = TRUE)
+      cor.bins <- getCorMatrix(s.bins, squeeze = !group)
       #Stupid check for perfect correlation with global mean
       if (any(is.na(cor.bins$binmat.cor))) {
         absig <- matrix(rep(NA, nrow(cor.bins$binmat.cor)))
@@ -90,7 +89,7 @@ bootstrapCompartments <- function(obj, original.obj, bootstrap.samples = 1000,
       colnames(boot.mean) <- "globalMean"
       s.bins <- shrinkBins(obj, original.obj, prior.means = boot.mean,
                            chr = chr, res = res, assay = assay, genome = genome)
-      cor.bins <- getCorMatrix(s.bins, squeeze = TRUE)
+      cor.bins <- getCorMatrix(s.bins, squeeze = !group)
       #Stupid check for perfect correlation with global mean
       if (any(is.na(cor.bins$binmat.cor))) {
         absig <- matrix(rep(NA, nrow(cor.bins$binmat.cor)))


### PR DESCRIPTION
- use the group bool to set squeeze arg in getCorMatrix
This was only specified in the non-parallel version - is there a difference in group treatments when running parallel vs serial?

- collapse the lapply and mclapply setting mc.cores to 1 if not parallel