### PR TITLE
refactor(scCompartments): replace double get*ABsignal calls with single call

### DIFF
--- a/R/scCompartments.R
+++ b/R/scCompartments.R
@@ -36,15 +36,10 @@ scCompartments <- function(obj, res = 1e6, parallel = FALSE, chr = NULL,
   #which assay are we working on
   assay <- tolower(match.arg(assay))
   if (!assay %in% c("atac", "rna")) stop("Supported assays are 'atac', and 'rna'.")
-  
-  sc_compartments <- switch(assay,
-                            atac=getATACABsignal(obj = obj, res = res, parallel = parallel,
+
+  sc_compartments <- getATACABsignal(obj = obj, res = res, parallel = parallel,
                                                  chr = chr, targets = targets, cores = cores,
                                                  bootstrap = bootstrap, num.bootstraps = num.bootstraps,
-                                                 genome = genome, group = group),
-                            rna=getRNAABsignal(obj = obj, res = res, parallel = parallel,
-                                               chr = chr, targets = targets, cores = cores,
-                                               bootstrap = bootstrap, num.bootstraps = num.bootstraps,
-                                               genome = genome, group = group))
+                                                 genome = genome, group = group)
   return(sc_compartments)
 }

--- a/R/scCompartments.R
+++ b/R/scCompartments.R
@@ -1,6 +1,6 @@
 #' @title Estimate A/B compartments from single-cell sequencing data
 #'
-#' @description 
+#' @description
 #' \code{scCompartments} returns estimated A/B compartments from sc-seq data.
 #'
 #' @param obj Input SummarizedExperiment object
@@ -22,24 +22,38 @@
 #' @export
 #' @examples
 #' data("k562_scrna_chr14", package = "compartmap")
-#' sc_compartments <- scCompartments(k562_scrna_chr14, parallel=FALSE, chr="chr14", bootstrap=FALSE, genome="hg19")
-
-scCompartments <- function(obj, res = 1e6, parallel = FALSE, chr = NULL,
-                           targets = NULL, cores = 2,
-                           bootstrap = TRUE, num.bootstraps = 100,
-                           genome = c("hg19", "hg38", "mm9", "mm10"),
-                           group = FALSE, assay = c("atac", "rna")) {
-  
-  #make sure we have a SummarizedExperiment flavored object
+#' sc_compartments <- scCompartments(k562_scrna_chr14, parallel = FALSE, chr = "chr14", bootstrap = FALSE, genome = "hg19")
+scCompartments <- function(
+  obj,
+  res = 1e6,
+  parallel = FALSE,
+  chr = NULL,
+  targets = NULL,
+  cores = 2,
+  bootstrap = TRUE,
+  num.bootstraps = 100,
+  genome = c("hg19", "hg38", "mm9", "mm10"),
+  group = FALSE,
+  assay = c("atac", "rna")
+) {
+  # make sure we have a SummarizedExperiment flavored object
   if (!checkAssayType(obj)) stop("Input object needs to be a SummarizedExperiment.")
-  
-  #which assay are we working on
+
+  # which assay are we working on
   assay <- tolower(match.arg(assay))
   if (!assay %in% c("atac", "rna")) stop("Supported assays are 'atac', and 'rna'.")
 
-  sc_compartments <- getATACABsignal(obj = obj, res = res, parallel = parallel,
-                                                 chr = chr, targets = targets, cores = cores,
-                                                 bootstrap = bootstrap, num.bootstraps = num.bootstraps,
-                                                 genome = genome, group = group)
+  sc_compartments <- getATACABsignal(
+    obj = obj,
+    res = res,
+    parallel = parallel,
+    chr = chr,
+    targets = targets,
+    cores = cores,
+    bootstrap = bootstrap,
+    num.bootstraps = num.bootstraps,
+    genome = genome,
+    group = group
+  )
   return(sc_compartments)
 }


### PR DESCRIPTION
From https://github.com/jamespeapen/compartmap/blob/c42d722aa6b729e79a13bdd31e3910175935a368/R/getATACABsignal.R#L192
```
#' @describeIn getATACABsignal Alias for getATACABsignal
#'
getRNAABsignal <- getATACABsignal
```

Is the RNA meant to be a different function?