### PR TITLE
refactor(filterCompartments)

### DIFF
--- a/R/filterCompartments.R
+++ b/R/filterCompartments.R
@@ -18,33 +18,26 @@ filterCompartments <- function(obj, min.conf = 0.7, min.eigen = 0.02) {
   message("Filtering compartments based on a minimum absolute eigen value of ", min.eigen)
   if (is(obj, "list")) {
     filt.compartments <- lapply(obj, function(x) {
-      filt <- apply(mcols(x), 1, function(r) {
-        #check if we have "fixed" things
-        if ("flip.score" %in% names(r)) {
-          filt.score <- ifelse(as.numeric(r["flip.conf.est"]) >= min.conf &
-                                 abs(as.numeric(r["flip.score"])) >= min.eigen,
-                               TRUE, FALSE)
-          return(filt.score)
-        } else {
-          return(ifelse(as.numeric(r["conf.est"]) >= min.conf &
-                          abs(as.numeric(r["score"])) >= min.eigen, TRUE, FALSE))
-        }
-      })
+      filt <- filterer(x, min.conf, min.eigen)
       return(x[filt,])
     })
   } else {
-    filt <- apply(mcols(obj), 1, function(r) {
-      #check if we have "fixed" things
-      if ("flip.score" %in% names(r)) {
-        filt.score <- ifelse(as.numeric(r["flip.conf.est"]) >= min.conf &
-                               abs(as.numeric(r["flip.score"])) >= min.eigen,
-                             TRUE, FALSE)
-        return(filt.score)
-      } else {
-        return(ifelse(as.numeric(r["conf.est"]) >= min.conf &
-                        abs(as.numeric(r["score"])) >= min.eigen, TRUE, FALSE))
-      }
-    })
+    filt <- filterer(obj, min.conf, min.eigen)
     return(obj[filt,])
   }
+}
+
+filterer <- function(obj, min.conf, min.eigen) {
+  apply(mcols(obj), 1, function(x) {
+    #check if we have "fixed" things
+    if ("flip.score" %in% names(x)) {
+      filt.score <- ifelse(as.numeric(x["flip.conf.est"]) >= min.conf &
+        abs(as.numeric(x["flip.score"])) >= min.eigen,
+        TRUE, FALSE)
+      return(filt.score)
+    } else {
+      return(ifelse(as.numeric(x["conf.est"]) >= min.conf &
+        abs(as.numeric(x["score"])) >= min.eigen, TRUE, FALSE))
+    }
+  })
 }

--- a/R/filterCompartments.R
+++ b/R/filterCompartments.R
@@ -1,5 +1,5 @@
 #' Filter compartments using confidence estimates and eigenvalue thresholds
-#' 
+#'
 #' @name filterCompartments
 #'
 #' @param obj Output of condenseSE or fixCompartments
@@ -11,29 +11,29 @@
 #' @export
 #'
 #' @examples
-#' 
 filterCompartments <- function(obj, min.conf = 0.7, min.eigen = 0.02) {
-  #filter compartments
-  message("Filtering compartments based on a minimum confidence of ", min.conf*100, "%")
+  # filter compartments
+  message("Filtering compartments based on a minimum confidence of ", min.conf * 100, "%")
   message("Filtering compartments based on a minimum absolute eigen value of ", min.eigen)
   if (is(obj, "list")) {
     filt.compartments <- lapply(obj, function(x) {
       filt <- filterer(x, min.conf, min.eigen)
-      return(x[filt,])
+      return(x[filt, ])
     })
   } else {
     filt <- filterer(obj, min.conf, min.eigen)
-    return(obj[filt,])
+    return(obj[filt, ])
   }
 }
 
 filterer <- function(obj, min.conf, min.eigen) {
   apply(mcols(obj), 1, function(x) {
-    #check if we have "fixed" things
+    # check if we have "fixed" things
     if ("flip.score" %in% names(x)) {
       filt.score <- ifelse(as.numeric(x["flip.conf.est"]) >= min.conf &
         abs(as.numeric(x["flip.score"])) >= min.eigen,
-        TRUE, FALSE)
+      TRUE, FALSE
+      )
       return(filt.score)
     } else {
       return(ifelse(as.numeric(x["conf.est"]) >= min.conf &

--- a/R/filterCompartments.R
+++ b/R/filterCompartments.R
@@ -29,15 +29,10 @@ filterCompartments <- function(obj, min.conf = 0.7, min.eigen = 0.02) {
 filterer <- function(obj, min.conf, min.eigen) {
   apply(mcols(obj), 1, function(x) {
     # check if we have "fixed" things
-    if ("flip.score" %in% names(x)) {
-      filt.score <- ifelse(as.numeric(x["flip.conf.est"]) >= min.conf &
-        abs(as.numeric(x["flip.score"])) >= min.eigen,
-      TRUE, FALSE
-      )
-      return(filt.score)
-    } else {
-      return(ifelse(as.numeric(x["conf.est"]) >= min.conf &
-        abs(as.numeric(x["score"])) >= min.eigen, TRUE, FALSE))
-    }
+    flip <- "flip.score" %in% names(x)
+    conf.name <- ifelse(flip, "filp.conf.est", "conf.est")
+    score.name <- ifelse(flip, "filp.score", "score")
+    filt.score <- as.numeric(x[conf.name]) >= min.conf & abs(as.numeric(x[score.name])) >= min.eigen
+    return(filt.score)
   })
 }


### PR DESCRIPTION
In the original the filt.compartments is not returned after lapply creates it. Should a subset of it be returned like it is if `obj` is not a list?