### PR TITLE
refactor(utils): removeEmptyBoots

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -133,17 +133,15 @@ getChrs <- function(obj) {
 
 #' Remove bootstrap estimates that failed
 #'
-#' @param obj Input list object with elements 'pc' and 'gr'
+#' This can happen if the correlation between the bins and eigenvector fails
+#' theoretically we can recover these but need an additional utility to find
+#' consensus
 #'
+#' @param obj Input list object with elements 'pc' and 'gr'
 #' @return A filtered list object
 #' @export
 removeEmptyBoots <- function(obj) {
-  # remove NAs from a bootstrap list
-  # this can happen if the correlation between the bins and eigenvector fails
-  # theoretically we can recover these but need an additional utility to find consensus
-  na.filt <- unlist(lapply(obj, function(n) ifelse(any(is.na(n)), FALSE, TRUE)))
-  obj <- obj[na.filt]
-  return(obj)
+  Filter(Negate(anyNA), obj)
 }
 
 #' Get the seqlengths of a chromosome


### PR DESCRIPTION
Assumes that we're filtering empty/missing GRanges objects and not removing GRanges with NA's in its metadata columns. 