### PR TITLE
perf(getGlobalMean): speed up preComputeBootstraps

### DIFF
--- a/R/getGlobalMeans.R
+++ b/R/getGlobalMeans.R
@@ -79,6 +79,7 @@ precomputeBootstrapMeans <- function(
 ) {
   # this function precomputes the bootstrapped global means
   # as a default we will make 100 bootstraps
+  assay <- match.arg(assay)
   is.array <- assay == "array"
 
   if (!is.null(targets)) {
@@ -100,6 +101,12 @@ precomputeBootstrapMeans <- function(
 # Get $counts of $Beta depening on whether the input is an array experiment or rna/atac
 .getAssay <- function(obj, is.array) {
   assay.name <- ifelse(is.array, "Beta", "counts")
+
+  if (!assay.name %in% names(assays(obj))) {
+    msg <- paste(shQuote(assay.name), "not found in the input object's assays")
+    stop(msg)
+  }
+
   assay.data <- assays(obj)[[assay.name]]
   if (is.array) {
     assay.data <- flogit(assay.data)

--- a/R/getGlobalMeans.R
+++ b/R/getGlobalMeans.R
@@ -13,10 +13,10 @@
 #' @examples
 #' data("k562_scrna_chr14", package = "compartmap")
 #' scrna.global.means <- getGlobalMeans(k562_scrna_chr14, assay = "rna")
-#'
 getGlobalMeans <- function(obj, targets = NULL, assay = c("atac", "rna", "array")) {
   # match the assay arg
   assay <- match.arg(assay)
+  is.array <- assay == "array"
 
   # check the names of the assays
   if (!any(getAssayNames(obj) %in% c("counts", "Beta"))) {
@@ -34,11 +34,8 @@ getGlobalMeans <- function(obj, targets = NULL, assay = c("atac", "rna", "array"
     globalMean.input <- obj
   }
 
-  globalMean <- switch(assay,
-    atac = matrix(rowMeans(assays(globalMean.input)$counts, na.rm = TRUE), ncol = 1),
-    rna = matrix(rowMeans(assays(globalMean.input)$counts, na.rm = TRUE), ncol = 1),
-    array = matrix(rowMeans(flogit(assays(globalMean.input)$Beta), na.rm = TRUE), ncol = 1)
-  )
+  assay.data <- .getAssay(globalMean.input, is.array)
+  globalMean <- matrix(rowMeans(assay.data, na.rm = TRUE), ncol = 1)
 
   colnames(globalMean) <- "globalMean"
   # coercion to get the rownames to be the GRanges coordinates
@@ -77,6 +74,7 @@ precomputeBootstrapMeans <- function(
 ) {
   # this function precomputes the bootstrapped global means
   # as a default we will make 100 bootstraps
+  is.array <- assay == "array"
 
   bootMean <- mclapply(1:num.bootstraps, function(b) {
     message("Working on bootstrap ", b)
@@ -84,11 +82,9 @@ precomputeBootstrapMeans <- function(
       if (length(targets) < 5) stop("Need more than 5 samples for targeted bootstrapping to work.")
       obj <- getShrinkageTargets(obj, targets)
     }
-    resamp.mat <- switch(assay,
-      atac = .resampleMatrix(assays(obj)$counts),
-      rna = .resampleMatrix(assays(obj)$counts),
-      array = .resampleMatrix(assays(obj)$Beta)
-    )
+    assay.data <- .getAssay(obj, is.array)
+    resamp.mat <- .resampleMatrix(assay.data)
+
     # turn back into SummarizedExperiment
     resamp.se <- switch(assay,
       atac = SummarizedExperiment(
@@ -109,4 +105,14 @@ precomputeBootstrapMeans <- function(
   }, mc.cores = ifelse(parallel, num.cores, 1))
 
   return(do.call("cbind", bootMean))
+}
+
+# Get $counts of $Beta depening on whether the input is an array experiment or rna/atac
+.getAssay <- function(obj, is.array) {
+  assay.name <- ifelse(is.array, "Beta", "counts")
+  assay.data <- assays(obj)[[assay.name]]
+  if (is.array) {
+    assay.data <- flogit(assay.data)
+  }
+  return(assay.data)
 }


### PR DESCRIPTION
- remove `switch`s by extracting assay getting into function based on assay type, `flogit`ing when array
- speed up bootstrapping by extracting the `rowMean` calculator into a function that takes a matrix so that the resampled matrix doesn't need to be put into a SE object.
- 2-3x speed up on example rna data, 5x on array
I tested this on the array and scrna_chr14 data and the dims are matching between the old and new implementation but since its a random resampling not sure how to test.