### PR TITLE
fix(getShrinkageTargets): accept index or names, informative errors

### DIFF
--- a/R/getShrinkageTargets.R
+++ b/R/getShrinkageTargets.R
@@ -3,7 +3,8 @@
 #' @name getShrinkageTargets
 #'
 #' @param obj Input matrix
-#' @param group Samples/colnames to use for targeted shrinkage
+#' @param group Sample names, colnames or column indices to use for targeted
+#' shrinkage
 #'
 #' @return A matrix composed of samples to shrink towards
 #' @export
@@ -11,15 +12,22 @@
 #' @examples
 #' dummy <- matrix(rnorm(1000), ncol=25)
 #' dummy.sub <- getShrinkageTargets(dummy, group = c(1,5,8,10))
-#' 
-
 getShrinkageTargets <- function(obj, group) {
-  if (is.null(colnames(obj))) {
-    warning("No column names found to identify shrinkage targets.")
-    warning("Assuming group values are column indices.")
-    colnames(obj) <- seq_along(1:ncol(obj))
+  tryCatch(
+    obj[, unique(group)],
+    error = function(e) {
+      no_colnames <- is.null(colnames(obj))
+      group.is_colnames <- is.character(group)
+      column.type <- ifelse(group.is_colnames, "names", "indices")
+
+      msg <- paste(
+        "Error while subsetting targets: provided column", column.type, "not found:"
+      )
+      if (no_colnames & group.is_colnames) {
+        message("The provided object does not have any column names - use column indices instead.")
+      }
+      message(msg)
+      stop(e)
     }
-  if (all(group %in% colnames(obj))) stargets.obj <- obj[,group]
-  else (stop("Could not find ", group, " in the colnames of the input matrix..."))
-  return(stargets.obj)
+  )
 }

--- a/man/getShrinkageTargets.Rd
+++ b/man/getShrinkageTargets.Rd
@@ -9,7 +9,8 @@ getShrinkageTargets(obj, group)
 \arguments{
 \item{obj}{Input matrix}
 
-\item{group}{Samples/colnames to use for targeted shrinkage}
+\item{group}{Sample names, colnames or column indices to use for targeted
+shrinkage}
 }
 \value{
 A matrix composed of samples to shrink towards
@@ -20,5 +21,4 @@ Get the specified samples to shrink towards instead of the global mean
 \examples{
 dummy <- matrix(rnorm(1000), ncol=25)
 dummy.sub <- getShrinkageTargets(dummy, group = c(1,5,8,10))
-
 }


### PR DESCRIPTION
The original function did not subset a matrix with column names if indices were provided. It now subsets with either column names (if available) or indices. Error indicates whether names or indices were the issue and to use indices if colnames are not set. 
Depends on #54 