### PR TITLE
Summarize boots

### DIFF
--- a/R/agrestiCoullCI.R
+++ b/R/agrestiCoullCI.R
@@ -42,6 +42,9 @@ agrestiCoullCI <- function(n1, n0, q) {
   p_apx <- .p_approx(n1, n0, q)
   n_apx <- .n_approx(n1, n0, q)
   width <- .z(q) * sqrt( (p_apx/n_apx) * (1 - p_apx) )
-  res <- c(low=pmax(0, (p_apx - width)),est=p_apx,high=pmin((p_apx + width), 1))
-  return(res) 
+  data.frame(
+    conf.est = p_apx,
+    conf.est.lowerCI = pmax(0, (p_apx - width)),
+    conf.est.upperCI = pmin((p_apx + width), 1)
+  )
 }

--- a/R/summarizeBootstraps.R
+++ b/R/summarizeBootstraps.R
@@ -54,19 +54,6 @@ summarizeBootstraps <- function(boot.list, est.ab, q = 0.95, assay = c("rna", "a
   return(est.ab)
 }
 
-# Check if a compartment is open based on assay type and eigenvalue
-#
-# For ATAC/RNA:
-# eigen < 0 - closed
-# eigen > 0 - open
-#
-# For methylation the logic is flipped:
-# eigen < 0 - open
-# eigen > 0 - closed
-.isCompartmentOpen <- function(is.atac_or_rna, eigen) {
-  (is.atac_or_rna & eigen > 0) | (!is.atac_or_rna & eigen < 0)
-}
-
 .getSummary <- function(gr.boot, est.ab) {
   # add the pc to the granges object
   gr.boot$score <- gr.boot$pc

--- a/R/summarizeBootstraps.R
+++ b/R/summarizeBootstraps.R
@@ -64,7 +64,7 @@ summarizeBootstraps <- function(boot.list, est.ab, q = 0.95, assay = c("rna", "a
   est.ab.dummy$boot.closed <- 0
 
   # determine whether compartment is open and convert the boolean to 1/0 binary result for proportions
-  gr.boot.isOpen <- .isCompartmentOpen(is.atac_or_rna, gr.boot$score)
+  gr.boot.isOpen <- gr$compartments == "open"
   gr.boot$open <- as.integer(gr.boot.isOpen)
   gr.boot$closed <- as.integer(!gr.boot.isOpen)
 
@@ -82,10 +82,7 @@ summarizeBootstraps <- function(boot.list, est.ab, q = 0.95, assay = c("rna", "a
 
 .getCI <- function(gr.row, est.ab, q) {
   compartment.call <- est.ab[gr.row, ]
-  ab.score <- compartment.call$score
-
-  # check if the compartment is open
-  is.open <- .isCompartmentOpen(is.atac_or_rna, ab.score)
+  is.open <- compartment.call$compartments == "open"
 
   # get ones and zeroes input for agrestiCoullCI
   ones <- ifelse(is.open, compartment.call$boot.open, compartment.call$boot.closed)

--- a/R/summarizeBootstraps.R
+++ b/R/summarizeBootstraps.R
@@ -79,7 +79,7 @@ summarizeBootstraps <- function(boot.list, est.ab, q = 0.95, assay = c("rna", "a
     # get ones and zeroes input for agrestiCoullCI
     ones <- ifelse(is.open, compartment.call$boot.open, compartment.call$boot.closed)
     zeroes <- ifelse(is.open, compartment.call$boot.closed, compartment.call$boot.open)
-    agrestiCoullCI(ones, zeroes, q = 0.95)
+    agrestiCoullCI(ones, zeroes, q = q)
   })
 
   # combine the conf.est results into something sensible and bind with est.ab

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,34 +1,3 @@
-#' Get the open and closed compartment calls based on sign of singular values
-#'
-#' @param gr Input GRanges with associated mcols that represent singular values
-#' @param cutoff Threshold to define open and closed states
-#' @param assay The type of assay we are working with
-#'
-#' @return A vector of binary/categorical compartment states
-#' @import SummarizedExperiment
-#' @importFrom methods is
-#' @export
-#'
-#' @examples
-#'
-#' dummy <- matrix(rnorm(10000), ncol = 25)
-#' sing_vec <- getSVD(dummy, k = 1, sing.vec = "right")
-#'
-extractOpenClosed <- function(
-  gr,
-  cutoff = 0,
-  assay = c("rna", "atac", "array")
-) {
-  # check for input to be GRanges
-  if (!is(gr, "GRanges")) stop("Input needs to be a GRanges.")
-  if (!("pc" %in% names(mcols(gr)))) stop("Need to have an mcols column be named 'pc'.")
-
-  assay <- match.arg(assay)
-  is.atac_or_rna <- assay %in% c("atac", "rna")
-  is.open <- (is.atac_or_rna & gr$pc > cutoff) | (!is.atac_or_rna & gr$pc < cutoff)
-  ifelse(is.open, "open", "closed")
-}
-
 #' Check if the assay is a SummarizedExperiment
 #'
 #' @param obj Input object


### PR DESCRIPTION
- the input confidence level `q` is now being used
- lapply functions extracted so they can be tested
- Assuming that we can use the compartment call made by `extractOpenClosed()` instead of recomputing. It used to have a hardcoded 0 as a cutoff in `summarizeBootstraps()` but had an input cutoff argument in `extractOpenClosed()` with default 0.
- moved `.isCompartmentOpen()` to `getABSignal.R` - if we use the earlier open/closed call that's the only file it gets called in
- update `agrestiCoullCI()` to return a dataframe row so it can work with vector inputs and return a dataframe that can be plugged into the `mcols(est.ab)`
- vectorize CI computation
```
Unit: milliseconds
 expr          min        lq         mean       median     uq         max          neval
    lapply CI  188.891453 193.743578 200.713800 196.716700 198.881289 633.046724   100
 vectorized CI   3.807941   3.898602   3.963774   3.926279   3.975098   4.715911   100
```