### PR TITLE
fix(getGlobalMean): remove looped getAssay call

### DIFF
--- a/R/getGlobalMeans.R
+++ b/R/getGlobalMeans.R
@@ -84,9 +84,9 @@ precomputeBootstrapMeans <- function(
     if (length(targets) < 5) stop("Need more than 5 samples for targeted bootstrapping to work.")
     obj <- getShrinkageTargets(obj, targets)
   }
+  assay.data <- .getAssay(obj, is.array)
   bootMean <- mclapply(1:num.bootstraps, function(b) {
     message("Working on bootstrap ", b)
-    assay.data <- .getAssay(obj, is.array)
     resamp.mat <- .resampleMatrix(assay.data)
     computeGlobalMean(resamp.mat)
   }, mc.cores = ifelse(parallel, num.cores, 1))

--- a/R/getGlobalMeans.R
+++ b/R/getGlobalMeans.R
@@ -81,7 +81,7 @@ precomputeBootstrapMeans <- function(
   is.array <- assay == "array"
 
   if (!is.null(targets)) {
-    if (length(targets) < 5) stop("Need more than 5 samples for targeted bootstrapping to work.")
+    if (length(targets) < 5) stop("Need 5 or more samples for targeted bootstrapping to work.")
     obj <- getShrinkageTargets(obj, targets)
   }
   assay.data <- .getAssay(obj, is.array)


### PR DESCRIPTION
shave a second of runtime in the example

Error message for fewer than 5 targets should be 5 or more instead of more than 5.